### PR TITLE
Commit messages should begin with capital letter

### DIFF
--- a/gitStyleGuide/README.md
+++ b/gitStyleGuide/README.md
@@ -54,7 +54,7 @@ $ git branch --merged | grep -v `\\*`
 
 A commit message consists of three distinct parts separated by a blank line: the title, the (optional) body and the (optional) footer. The layout looks like this:
 ```
-feat: teach how to write commit message
+feat: Teach how to write commit message
 
 A further explanation is a good practice we recommend you follow.
 


### PR DESCRIPTION
O tópico de _Subject_ propõe que o assunto comece com a primeira letra em maiúsculo, conforme a proposição _Subjects should be no greater than 50 characters, **should begin with a capital letter** and do not end with a period_. Estou propondo esta modificação para evitar confusões e tornar o texto mais coerente.